### PR TITLE
add check on fgets before trim

### DIFF
--- a/plugins/monitoring/nagios/lib.php
+++ b/plugins/monitoring/nagios/lib.php
@@ -42,7 +42,11 @@ function plugin_nagios_update(Plugin $plugin) {
     // Parse le fichier status.dat de Nagios.
     $services = array();
     while (feof($handle) === false) {
-        $line = trim(fgets($handle, 4096));
+        $line =fgets($handle, 4096);
+        if ($line === false){
+            continue;
+        }
+        $line = trim($line);
         if (preg_match('/^servicestatus \{/', $line) === 1) {
             $service = new stdClass();
             $service->name = '@';


### PR DESCRIPTION
Bonjour,
Avec la dernière version de centreon, j'avais des erreurs sur des lignes du status.dat. J'ai donc ajouter un check sur le retour du fgets avant de faire un trim.